### PR TITLE
deleting source tree and adding mocha as dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Project for API Technical Test
 
 ### Installing
 
-#. Install Node.js
-#. Install GIT
-#. Clone metrolab-techtest-api project
+1. Install Node.js
+2. Install GIT
+3. Clone metrolab-techtest-api project
 
 ### Running Tests
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,12 @@ Project for API Technical Test
 
 * [Node.Js](https://nodejs.org/en/download/)
 * [GIT](https://git-scm.com/downloads)
-* [SourceTree](https://www.sourcetreeapp.com/)
 
 ### Installing
 
-1. Install Node.js
-2. Install GIT
-3. Install SourceTree
-4. Clone metrolab-techtest-api project
+#. Install Node.js
+#. Install GIT
+#. Clone metrolab-techtest-api project
 
 ### Running Tests
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ Project for API Technical Test
 
 ### Prerequisites
 
-* [Node.Js](https://nodejs.org/en/download/)
 * [GIT](https://git-scm.com/downloads)
+* [Node.Js](https://nodejs.org/en/download/)
+* [Mocha](https://www.npmjs.com/package/mocha)
 
 ### Installing
 
-1. Install Node.js
-2. Install GIT
+1. Install GIT
+2. Install Node.js
+3. Install Mocha
 3. Clone metrolab-techtest-api project
 
 ### Running Tests


### PR DESCRIPTION
Deleting `source tree` and adding `mocha` dependencies.

For some reason, even though Mocha seems to be in the `package.json` file, that dependency was not installed when I did `npm install`.
![image](https://user-images.githubusercontent.com/5482105/42506278-b7949ac8-8441-11e8-9b79-4ce0e54c4a95.png)
